### PR TITLE
Support for up/down keys in iOS (terminal emulator)

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,14 +179,14 @@ Menu.prototype._drawRow = function (index) {
 
 Menu.prototype._ondataHandler = function ondata (buf) {
     var codes = [].join.call(buf, '.');
-    if (codes === '27.91.65' || codes === '107') { // up || k
+    if (codes === '27.91.65' || codes === '27.79.65' || codes === '107') { // up || up (iOS) || k
         this.selected = (this.selected - 1 + this.items.length)
             % this.items.length
         ;
         this._drawRow(this.selected + 1);
         this._drawRow(this.selected);
     }
-    else if (codes === '27.91.66' || codes === '106') { // down || j
+    else if (codes === '27.91.66' || codes === '27.79.66' || codes === '106') { // down || down (iOS) || j
         this.selected = (this.selected + 1) % this.items.length;
         this._drawRow(this.selected - 1);
         this._drawRow(this.selected);


### PR DESCRIPTION
I was trying to run through the nodeschool apps using an iOS terminal emulator (ex: Cathode) connected to a host running node and noticed that the up/down arrow keys didn't work in the menu. I used the code from this module to write a throwaway echo program and observed that iOS was producing x.79.y instead of x.91.y. I've verified this in a couple different emulator apps, so I'm assuming this is an iOS thing and not a quirk of the emulator. I haven't been able to find a reference that would make this more authoritative, but here's a PR based on what I can observe. (iOS7 on an iPad mini)
