### PR TITLE
Restore cursor after pressing "Ctrl+C" or "Q"

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,9 +204,9 @@ Menu.prototype._ondata = function ondata (buf) {
             else bytes.splice(0, 3);
         }
         else if (/^(3|113)/.test(codes)) { // ^C or q
+            this.y = 0;
             this.charm.reset();
-            this._input.end();
-            this._output.end();
+            this.close();
             bytes.shift();
         }
         else if (/^(13|10)\b/.test(codes)) { // enter


### PR DESCRIPTION
A more complete version of #31.

Fixes #30.